### PR TITLE
模版导出增加BigDecimal类型数据

### DIFF
--- a/src/main/java/com/github/crab2died/handler/SheetTemplateHandler.java
+++ b/src/main/java/com/github/crab2died/handler/SheetTemplateHandler.java
@@ -267,6 +267,11 @@ public class SheetTemplateHandler {
             template.currentColumnIndex++;
             return;
         }
+		if (BigDecimal.class == value.getClass()) {
+			cell.setCellStyle((BigDecimal) value);
+			template.currentColumnIndex++;
+			return;
+		}
         template.currentColumnIndex++;
     }
 


### PR DESCRIPTION
有些货币类型一般都是用BigDecimal类型，建议作者把这个pull接受了。